### PR TITLE
! fix equals for comparing by milliseconds because of java.sql.Timestamp

### DIFF
--- a/src/main/java/cz/muni/fi/pa165/entity/Flight.java
+++ b/src/main/java/cz/muni/fi/pa165/entity/Flight.java
@@ -110,12 +110,12 @@ public class Flight {
 		if (arrival == null) {
 			if (other.getArrival() != null)
 				return false;
-		} else if (!arrival.equals(other.getArrival()))
+		} else if (! (arrival.getTime() == other.getArrival().getTime())) //override for Timestamp's violation of equals
 			return false;
 		if (departure == null) {
 			if (other.getDeparture() != null)
 				return false;
-		} else if (!departure.equals(other.getDeparture()))
+		} else if (! (departure.getTime() == other.getDeparture().getTime())) //override for Timestamp's violation of equals
 			return false;
 		if (from == null) {
 			if (other.getFrom() != null)


### PR DESCRIPTION
Runtime types returned from database are java.sql.Timestamp and this class violates general contract of equals method (not symmetric). Timestamp saves nanoseconds which does not appear in java.util.Date and therefore Timestamp does not found nanoseconds in Date and claims, that any Date is not equal to it. If called on Date object, equals works fine.
